### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For installation instructions from binaries please visit the [Releases Page](htt
 #### Via Go
 
 ```console
-$ go get github.com/genuinetools/pepper
+$ go install github.com/genuinetools/pepper@latest
 ```
 
 ## Usage


### PR DESCRIPTION
The current command does not work with newer versions of Go:

```
go get github.com/genuinetools/pepper
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```